### PR TITLE
Added endif statement to controlvec that had been inadvertently removed.

### DIFF
--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -374,6 +374,7 @@ if (nproc <= ntasks_io-1) then
          enddo
       endif
    end if
+   end if
    if (.not. paranc) then
       if (write_fv3_incr) then
          if (global_2mDA) then


### PR DESCRIPTION
Looks like we accidentally deleted an endif. Adding it back in.